### PR TITLE
CASMPET-7526: Break keycloak installer into different repos

### DIFF
--- a/.github/workflows/chart-lint-test-scan.yml
+++ b/.github/workflows/chart-lint-test-scan.yml
@@ -21,16 +21,27 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-apiVersion: v2
-appVersion: 3.9.0
-name: cray-keycloak-users-localize
-version: 1.11.7
-description: Customizes Keycloak deployment
-keywords:
-- keycloak
-- keycloak-users-localize
-home: https://github.com/Cray-HPE/cray-keycloak-users-localize
-maintainers:
-- name: ndavidson-hpe
-annotations:
-  artifacthub.io/license: MIT
+name: Lint, test, and scan Helm charts
+on:
+  pull_request:
+    branches:
+      - master
+      - release/**
+  workflow_dispatch:
+jobs:
+  lint-test-scan:
+    uses: Cray-HPE/.github/.github/workflows/charts-lint-test-scan.yml@main
+    with:
+      scan-image-snyk-args: "--severity-threshold=high"
+      lint-charts: ${{ github.event_name == 'pull_request' }}
+      ct-config: |
+        chart-dirs:
+          - kubernetes
+        validate-maintainers: false
+      scan-chart-snyk-args: "--severity-threshold=high --policy-path=kubernetes/.snyk"
+      scan-images: false
+    secrets:
+      snyk-token: ${{ secrets.SNYK_TOKEN }}
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      artifactory-username: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
+      artifactory-password: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.coverage
+results/*
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [1.0.0] - 2017-06-20
+## [5.1.4] - 2025-05-28
 ### Added
-- [...]
- 
-### Changed
-- [...]
+- Initial release from new repo
 
-### Removed
-- [...]

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -1,0 +1,67 @@
+/*
+ *
+ *  MIT License
+ *
+ *  (C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included
+ *  in all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ *  OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ *  ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *  OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+ @Library('csm-shared-library') _
+
+
+pipeline {
+    agent {
+        label "metal-gcp-builder"
+    }
+
+    options {
+        buildDiscarder(logRotator(numToKeepStr: "10"))
+        timestamps()
+    }
+
+    environment {
+        IS_STABLE = getBuildIsStable()
+
+        DESCRIPTION = "HPE Keycloak users localize Chart"
+        CHART_NAME = "cray-keycloak-users-localize"
+        CHART_VERSION = getChartVersion(name: env.CHART_NAME, isStable: env.IS_STABLE)
+
+    }
+
+    stages {
+        stage("Build") {
+            parallel {
+                stage('Chart') {
+                    steps {
+                        sh "make charts"
+                    }
+                }
+            }
+        }
+
+        stage('Publish ') {
+            steps {
+                script {
+                    publishCsmHelmCharts(component: env.CHART_NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged/${CHART_NAME}", isStable: env.IS_STABLE)
+                }
+            }
+        }
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+#
+# MIT License
+#
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+# (MIT License)
+
+# HELM CHARTS
+CHART_PATH ?= kubernetes
+CHART_VERSION ?= local
+CHART_NAME ?= "cray-keycloak-users-localize"
+HELM_UNITTEST_IMAGE ?= quintush/helm-unittest:3.3.0-0.2.5
+
+all : charts
+charts: chart_setup chart_package chart_tests
+chart_tests: chart_test
+
+chart_setup:
+		mkdir -p ${CHART_PATH}/.packaged
+
+chart_package:
+		helm dep up ${CHART_PATH}/${CHART_NAME}
+		helm package ${CHART_PATH}/${CHART_NAME} -d ${CHART_PATH}/.packaged/${CHART_NAME} --version ${CHART_VERSION}
+
+chart_test:
+		helm lint "${CHART_PATH}/${CHART_NAME}"
+		docker run --rm -v ${PWD}/${CHART_PATH}:/apps ${HELM_UNITTEST_IMAGE} -3 ${CHART_NAME}
+
+

--- a/README.md
+++ b/README.md
@@ -1,53 +1,10 @@
-# csm-template
-
-Template for CSM repositories including basic files. This README is also...a template.
-
-See the suggested sections below, adapted from https://www.makeareadme.com/. Not all sections will make sense for all projects, use your best judgment.
-
-
 # Project Name
 
-_Choose a self-explaining name for your project._
+Cray-Keycloak-users-localize
 
 ## Description
 
-_Let people know what your project can do specifically. Provide context and add a link to any reference visitors might be unfamiliar with. A list of Features or a Background subsection can also be added here. If there are alternatives to your project, this is a good place to list differentiating factors._
-
-_If this repo is around only for historical purposes and the project is no longer used, state that in the TOP of the README._
-
-## Getting Started
-
-_This is an example of how you may give instructions on setting up your project locally. To get a local copy up and running follow these simple example steps._
-
-_Listing specific steps helps remove ambiguity and gets people to using your project as quickly as possible._ 
-
-### Prerequisites
-
-_If your project only runs in a specific context like a particular programming language version or operating system or has dependencies that have to be installed manually, also add a Prerequisites subsection._
-
-### Installation
-
-### Usage
-
-_Use examples liberally, and show the expected output if you can. It's helpful to have inline the smallest example of usage that you can demonstrate, while providing links to more sophisticated examples in official documentation if they are too long to reasonably include in the README._
-
-_Depending on what you are making, it can be a good idea to include screenshots or even a video (you'll frequently see GIFs rather than actual videos). Tools like ttygif can help, but check out Asciinema for a more sophisticated method._
-
-## Compatibility
-
-_List the versions of the project and their associated dependencies and any other compatibility information. A table is often the easiest way to communicate compatibility information. The [Kubernetes python client](https://github.com/kubernetes-client/python#compatibility) is a good example._
-
-## Support
-
-_Tell people where they can go to for help. It can be any combination of an issue tracker, a chat room, an email address, official documentation, etc._
-
-* [Slack Channel(s)]
-* [Admin or installation guide section]
-* [CSM SIG group discussions in Cray-HPE/community repository]
-
-## Roadmap (optional)
-
-_If you have ideas for releases in the future, it is a good idea to provide links to the roadmap, wherever they reside (CASMFEAT-###)._
+This chart runs the keycloak-setup docker image from [keycloak-installer](https://github.com/Cray-HPE/keycloak-installer) to run the [keycloak_localize.py](https://github.com/Cray-HPE/keycloak-installer/blob/master/keycloak_setup/keycloak_localize.py) script.
 
 ## Contributing
 
@@ -57,9 +14,6 @@ See the [CONTRIBUTING.md](CONTRIBUTING.md) file for how to contribute to this pr
 
 See the [CHANGELOG.md](CHANGELOG.md) for the changes and release history of this project.
 
-## Authors and Acknowledgments (optional)
-
-_Show your appreciation to those who have contributed to the project._
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Cray-Keycloak-users-localize
 
 This chart runs the keycloak-setup docker image from [keycloak-installer](https://github.com/Cray-HPE/keycloak-installer) to run the [keycloak_localize.py](https://github.com/Cray-HPE/keycloak-installer/blob/master/keycloak_setup/keycloak_localize.py) script.
 
+### Updating the Docker Image
+
+Please update and create the change in the keycloak-installer repo. Once that is released then
+change the chart version, and the app version in the Chart.yaml file. Also update the image
+tag in the Values file.
+
 ## Contributing
 
 See the [CONTRIBUTING.md](CONTRIBUTING.md) file for how to contribute to this project.

--- a/kubernetes/cray-keycloak-users-localize/Chart.yaml
+++ b/kubernetes/cray-keycloak-users-localize/Chart.yaml
@@ -1,0 +1,37 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+apiVersion: v2
+name: cray-keycloak-users-localize
+version: 1.11.6
+description: Customizes Keycloak deployment
+keywords:
+- keycloak
+- keycloak-users-localize
+home: https://github.com/Cray-HPE/keycloak-installer
+sources:
+- https://github.com/Cray-HPE/keycloak-installer
+maintainers:
+- name: brantk-hpe
+annotations:
+  artifacthub.io/license: MIT

--- a/kubernetes/cray-keycloak-users-localize/templates/_helpers.tpl
+++ b/kubernetes/cray-keycloak-users-localize/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cray-keycloak-users-localize.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a global for the Chart.yaml appVersion field.
+Use a default of "latest" to keep some sort of backwards compatibility.
+*/}}
+{{- define "cray-keycloak-users-localize.app-version" -}}
+{{- default "latest" .Chart.AppVersion | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cray-keycloak-users-localize.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cray-keycloak-users-localize.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "cray-keycloak-users-localize.labels" -}}
+helm.sh/chart: {{ include "cray-keycloak-users-localize.chart" . }}
+{{ include "cray-keycloak-users-localize.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cray-keycloak-users-localize.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cray-keycloak-users-localize.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cray-keycloak-users-localize.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cray-keycloak-users-localize.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
+++ b/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
+++ b/kubernetes/cray-keycloak-users-localize/templates/keycloak-users-localize.yaml
@@ -1,0 +1,243 @@
+{{/*
+MIT License
+
+(C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: keycloak-users-localize
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: configmap-creator
+rules:
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, create, patch]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: keycloak-users-localize
+subjects:
+  - kind: ServiceAccount
+    name: keycloak-users-localize
+    namespace: services
+roleRef:
+  kind: ClusterRole
+  name: configmap-creator
+  apiGroup: rbac.authorization.k8s.io
+
+---
+kind: Job
+apiVersion: batch/v1
+metadata:
+  name: keycloak-users-localize-{{ .Release.Revision }}
+  labels:
+    {{- include "cray-keycloak-users-localize.labels" . | nindent 4 }}
+spec:
+  ttlSecondsAfterFinished: 2147483647
+  backoffLimit: {{ .Values.backoffLimit }}
+  template:
+    spec:
+      serviceAccountName: keycloak-users-localize
+      restartPolicy: Never
+      containers:
+      - name: keycloak-localize
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag | default (include "cray-keycloak-users-localize.app-version" . ) }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
+        env:
+        - name: KEYCLOAK_BASE
+          value: {{ .Values.keycloakBase }}
+        - name: OAUTHLIB_INSECURE_TRANSPORT  # Tell oauthlib to allow http. istio protects the channel
+          value: "1"
+        - name: LDAP_CONNECTION_URL
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-users-localize
+              key: ldap_connection_url
+        - name: LDAP_PROVIDER_ID
+          value: {{ .Values.ldapProviderId | quote }}
+        - name: LDAP_FEDERATION_NAME
+          value: {{ .Values.ldapFederationName | quote }}
+        - name: LDAP_PRIORITY
+          value: {{ .Values.ldapPriority | quote }}
+        - name: LDAP_EDIT_MODE
+          value: {{ .Values.ldapEditMode | quote }}
+        - name: LDAP_SYNC_REGISTRATIONS
+          value: {{ .Values.ldapSyncRegistrations | quote }}
+        - name: LDAP_LDAP_VENDOR
+          value: {{ .Values.ldapVendor | quote }}
+        - name: LDAP_USERNAME_LDAP_ATTRIBUTE
+          value: {{ .Values.ldapUsernameLDAPAttribute | quote }}
+        - name: LDAP_RDN_LDAP_ATTRIBUTE
+          value: {{ .Values.ldapRdnLDAPAttribute | quote }}
+        - name: LDAP_UUID_LDAP_ATTRIBUTE
+          value: {{ .Values.ldapUuidLDAPAttribute | quote }}
+        - name: LDAP_USER_OBJECT_CLASSES
+          value: {{ .Values.ldapUserObjectClasses | quote }}
+        - name: LDAP_AUTH_TYPE
+          value: {{ .Values.ldapAuthType | quote }}
+        - name: LDAP_BIND_DN
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-users-localize
+              key: ldap_bind_dn
+              optional: true
+        - name: LDAP_BIND_CREDENTIALS
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-users-localize
+              key: ldap_bind_credentials
+              optional: true
+        - name: LDAP_SEARCH_BASE
+          value: {{ .Values.ldapSearchBase | quote }}
+        - name: LDAP_SEARCH_SCOPE
+          value: {{ .Values.ldapSearchScope | quote }}
+        - name: LDAP_USE_TRUSTSTORE_SPI
+          value: {{ .Values.ldapUseTruststoreSpi | quote }}
+        - name: LDAP_CONNECTION_POOLING
+          value: {{ .Values.ldapConnectionPooling | quote }}
+        - name: LDAP_PAGINATION
+          value: {{ .Values.ldapPagination | quote }}
+        - name: LDAP_ALLOW_KERBEROS_AUTHENTICATION
+          value: {{ .Values.ldapAllowKerberosAuthentication | quote }}
+        - name: LDAP_BATCH_SIZE_FOR_SYNC
+          value: {{ .Values.ldapBatchSizeForSync | quote }}
+        - name: LDAP_FULL_SYNC_PERIOD
+          value: {{ .Values.ldapFullSyncPeriod | quote }}
+        - name: LDAP_CHANGED_SYNC_PERIOD
+          value: {{ .Values.ldapChangedSyncPeriod | quote }}
+        - name: LDAP_DEBUG
+          value: {{ .Values.ldapDebug | quote }}
+        - name: LDAP_ENABLED
+          value: {{ .Values.ldapEnabled | quote }}
+        - name: LDAP_USER_ATTRIBUTE_MAPPERS
+          value: {{ .Values.ldapUserAttributeMappers | toJson | quote }}
+        - name: LDAP_USER_ATTRIBUTE_MAPPERS_TO_REMOVE
+          value: {{ .Values.ldapUserAttributeMappersToRemove | toJson | quote }}
+        - name: LDAP_GROUP_NAME_LDAP_ATTR
+          value: {{ .Values.ldapGroupNameLDAPAttribute | quote }}
+        - name: LDAP_GROUP_OBJECT_CLASS
+          value: {{ .Values.ldapGroupObjectClass | quote }}
+        - name: LDAP_PRESERVE_GROUP_INHERITANCE
+          value: {{ .Values.ldapPreserveGroupInheritance | quote }}
+        - name: LDAP_GROUP_MEMBERSHIP_ATTRIBUTE
+          value: {{ .Values.ldapMembershipLDAPAttribute | quote }}
+        - name: LDAP_GROUP_MEMBERSHIP_ATTR_TYPE
+          value: {{ .Values.ldapMembershipAttributeType | quote }}
+        - name: LDAP_GROUP_MEMBERSHIP_LDAP_ATTR
+          value: {{ .Values.ldapMembershipUserLDAPAttribute | quote }}
+        - name: LDAP_GROUP_FILTER
+          value: {{ .Values.ldapGroupsLDAPFilter | quote }}
+        - name: LDAP_USER_ROLES_RETRIEVE_STRATEGY
+          value: {{ .Values.ldapUserRolesRetrieveStrategy | quote }}
+        - name: LDAP_MAPPED_GROUP_ATTRS
+          value: {{ .Values.ldapMappedGroupAttributes | quote }}
+        - name: LDAP_GROUPS_DROP_DURING_SYNC
+          value: {{ .Values.ldapDropNonExistingGroupsDuringSync | quote }}
+        - name: LDAP_ROLE_MAPPER_DN
+          value: {{ .Values.ldapRoleMapperDn | quote }}
+        - name: LDAP_ROLE_MAPPER_NAME_LDAP_ATTR
+          value: {{ .Values.ldapRoleMapperRoleNameLDAPAttribute | quote }}
+        - name: LDAP_ROLE_MAPPER_OBJECT_CLASS
+          value: {{ .Values.ldapRoleMapperRoleObjectClasses | quote }}
+        - name: LDAP_ROLE_MAPPER_MEMBERSHIP_LDAP_ATTR
+          value: {{ .Values.ldapRoleMapperLDAPAttribute | quote }}
+        - name: LDAP_ROLE_MAPPER_MEMBERSHIP_ATTR_TYPE
+          value: {{ .Values.ldapRoleMapperMemberAttributeType | quote }}
+        - name: LDAP_ROLE_MAPPER_MEMBERSHIP_USER_LDAP_ATTR
+          value: {{ .Values.ldapRoleMapperUserLDAPAttribute | quote }}
+        - name: LDAP_ROLE_MAPPER_ROLE_LDAP_FILTER
+          value: {{ .Values.ldapRoleMapperRolesLDAPFilter | quote }}
+        - name: LDAP_ROLE_MAPPER_MODE
+          value: {{ .Values.ldapRoleMapperMode | quote }}
+        - name: LDAP_ROLE_MAPPER_RETRIEVE_STRATEGY
+          value: {{ .Values.ldapRoleMapperStrategy | quote }}
+        - name: LDAP_ROLE_MAPPER_MEMBEROF_ATTR
+          value: {{ .Values.ldapRoleMapperMemberOfLDAPAttribute | quote }}
+        - name: LDAP_ROLE_MAPPER_USE_REALM_ROLES_MAPPING
+          value: {{ .Values.ldapRoleMapperUseRealmRolesMapping | quote }}
+        - name: LDAP_ROLE_MAPPER_CLIENT_ID
+          value: {{ .Values.ldapRoleMapperClientId | quote }}
+        - name: LDAP_DO_FULL_SYNC
+          value: {{ .Values.ldapDoFullSync | quote }}
+        - name: USER_EXPORT_STORAGE_URL
+          value: {{ .Values.userExportStorageUrl | quote }}
+        - name: USER_EXPORT_STORAGE_BUCKET
+          value: {{ .Values.userExportStorageBucket | quote }}
+        - name: USER_EXPORT_STORAGE_PASSWD_OBJECT
+          value: {{ .Values.userExportStoragePasswdObject | quote }}
+        - name: USER_EXPORT_NAME_SOURCE
+          value: {{ .Values.userExportNameSource | quote }}
+        - name: USER_EXPORT_GROUPS
+          value: {{ .Values.userExportGroups | quote }}
+        - name: USER_EXPORT_STORAGE_GROUPS_OBJECT
+          value: {{ .Values.userExportStorageGroupsObject | quote }}
+        - name: USER_EXPORT_NAMESPACES
+          value: {{ .Values.userExportNamespaces | toJson | quote }}
+        - name: USER_EXPORT_PASSWD_CONFIGMAP
+          value: {{ .Values.userExportUsersConfigmap | quote }}
+        - name: USER_EXPORT_GROUPS_CONFIGMAP
+          value: {{ .Values.userExportGroupsConfigmap | quote }}
+        - name: LOCAL_ROLE_ASSIGNMENTS
+          value: {{ .Values.localRoleAssignments | toJson | quote }}
+        volumeMounts:
+        - name: keycloak-master-admin-auth-vol
+          mountPath: /mnt/keycloak-master-admin-auth-vol
+        - name: keycloak-setup-vol
+          mountPath: /mnt/keycloak-setup-vol
+        - name: local-users-vol
+          mountPath: /mnt/local-users
+        - name: local-groups-vol
+          mountPath: /mnt/local-groups
+        - name: ceph-access-vol
+          mountPath: /mnt/ceph-access-vol
+        command:
+        - python
+        - keycloak_setup/keycloak_localize.py
+      volumes:
+      - name: keycloak-master-admin-auth-vol
+        secret:
+          secretName: {{ .Values.keycloakMasterAdminSecretName }}
+      - name: keycloak-setup-vol
+        secret:
+          secretName: {{ .Values.keycloakSetupSecretName }}
+      - name: local-users-vol
+        secret:
+          secretName: {{ .Values.localUsersSecretName }}
+          optional: true
+      - name: local-groups-vol
+        configMap:
+          name: {{ .Values.localGroupsConfigMapName }}
+          optional: true
+      - name: ceph-access-vol
+        secret:
+          secretName: {{ .Values.userStorageSecretName }}

--- a/kubernetes/cray-keycloak-users-localize/templates/sealedsecrets.yaml
+++ b/kubernetes/cray-keycloak-users-localize/templates/sealedsecrets.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/kubernetes/cray-keycloak-users-localize/templates/sealedsecrets.yaml
+++ b/kubernetes/cray-keycloak-users-localize/templates/sealedsecrets.yaml
@@ -1,6 +1,7 @@
+{{/*
 MIT License
 
-(C) Copyright 2025 Hewlett Packard Enterprise Development LP
+(C) Copyright 2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -19,3 +20,14 @@ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
 OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+*/}}
+{{- if .Values.sealedSecrets -}}
+{{- range $val := .Values.sealedSecrets }}
+{{- if $val.kind }}
+{{- if eq $val.kind "SealedSecret" }}
+---
+{{ toYaml $val }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/cray-keycloak-users-localize/values.yaml
+++ b/kubernetes/cray-keycloak-users-localize/values.yaml
@@ -1,0 +1,131 @@
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-keycloak-setup
+  tag: 3.9.0
+  pullPolicy: Always
+
+# Determines how many times the Job will retry running the localize pod.
+# If it takes longer for things to be ready this can be increased.
+backoffLimit: 3
+
+# Contains the creds for connecting to keycloak as the master administrator.
+keycloakMasterAdminSecretName: keycloak-master-admin-auth
+
+# The name of a secret that keycloak-setup creates when it's gotten far enough for the localization tool to run.
+keycloakSetupSecretName: admin-client-auth
+
+# If local users should be created, this secret contains the spec for the local users.
+# If this secret doesn't exist then local users will not be created.
+localUsersSecretName: keycloak-config-local-users
+
+# If local groups should be created, this secret contains the spec for the local groups.
+# If this secret doesn't exist then local groups will not be created.
+localGroupsConfigMapName: keycloak-config-local-groups
+
+# Contains the creds for connecting to the s3-style storage, exported users and groups files will be written here.
+userStorageSecretName: wlm-s3-credentials
+
+keycloakBase: http://cray-keycloak-http/keycloak
+
+# A list of sealedSecrets passed in to be deployed.
+sealedSecrets: []
+
+ldapProviderId: "ldap"
+ldapFederationName: "shasta-user-federation-ldap"
+ldapPriority: "1"
+ldapEditMode: "READ_ONLY"
+ldapSyncRegistrations: "false"
+ldapVendor: "other"
+ldapUsernameLDAPAttribute: "uid"
+ldapRdnLDAPAttribute: "uid"
+ldapUuidLDAPAttribute: "uid"
+ldapUserObjectClasses: "posixAccount"
+ldapAuthType: "none"
+ldapSearchBase: "cn=default"
+ldapSearchScope: "2"
+ldapUseTruststoreSpi: "ldapsOnly"
+ldapConnectionPooling: "true"
+ldapPagination: "true"
+ldapAllowKerberosAuthentication: "false"
+ldapBatchSizeForSync: "4000"
+ldapFullSyncPeriod: "-1"
+ldapChangedSyncPeriod: "-1"
+ldapDebug: "true"
+ldapEnabled: "true"
+
+ldapUserAttributeMappers:
+  - "uidNumber"
+  - "gidNumber"
+  - "loginShell"
+  - "homeDirectory"
+
+ldapUserAttributeMappersToRemove: []
+
+ldapGroupNameLDAPAttribute: "cn"
+ldapGroupObjectClass: "posixGroup"
+ldapPreserveGroupInheritance: "false"
+ldapMembershipLDAPAttribute: "memberUid"
+ldapMembershipAttributeType: "UID"
+ldapMembershipUserLDAPAttribute: "uid"
+ldapGroupsLDAPFilter: ""
+ldapUserRolesRetrieveStrategy: "LOAD_GROUPS_BY_MEMBER_ATTRIBUTE"
+ldapMappedGroupAttributes: "cn,gidNumber,memberUid"
+ldapDropNonExistingGroupsDuringSync: "false"
+
+ldapDoFullSync: "true"
+
+ldapRoleMapperDn: ""
+ldapRoleMapperRoleNameLDAPAttribute: "cn"
+ldapRoleMapperRoleObjectClasses: "groupOfNames"
+ldapRoleMapperLDAPAttribute: "member"
+ldapRoleMapperMemberAttributeType: "DN"
+ldapRoleMapperUserLDAPAttribute: "sAMAccountName"
+ldapRoleMapperRolesLDAPFilter: ""
+ldapRoleMapperMode: "READ_ONLY"
+ldapRoleMapperStrategy: "LOAD_ROLES_BY_MEMBER_ATTRIBUTE"
+ldapRoleMapperMemberOfLDAPAttribute: "memberOf"
+ldapRoleMapperUseRealmRolesMapping: "false"
+ldapRoleMapperClientId: "shasta"
+
+userExportUsersConfigmap: keycloak-users
+userExportGroupsConfigmap: keycloak-groups
+keycloak_ceph_secret: wlm-s3-credentials
+userExportStorageUrl: http://rgw-vip.nmn
+userExportStorageBucket: wlm
+userExportStoragePasswdObject: etc/passwd
+userExportStorageGroupsObject: etc/group
+userExportNamespaces:
+  - user
+  - default
+
+userExportNameSource: "username"
+  # The username stored in Keycloak is normalized to lowercase.
+  # If this is set to "homeDirectory" the username in the generated passwd file
+  # is built by pulling the last element from the homeDirectory path. This can
+  # be used to create a passwd file that preserves the case of the username.
+
+userExportGroups: "true"
+
+localRoleAssignments: []

--- a/kubernetes/cray-keycloak-users-localize/values.yaml
+++ b/kubernetes/cray-keycloak-users-localize/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

This breaks apart the keycloak chart from having 2 charts and a docker image in 1 repo to 3 repos for better version control.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [issue id](issue link)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

Tested on:

  * `<development system>`
  * Local development environment
  * Virtual Shasta

Test description:

_How were the changes tested and success verified? If schema changes were part of this change, how were those handled in your upgrade/downgrade testing?_

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?


## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
